### PR TITLE
Implement optional 'copy_symlinks' in config - to copy Symlinks as links rather than copying the target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## WIP
 
+- Add optional support to copy symlinks as links, rather than copying the target (via @jamesrtnz)
+
 ## Mackup 0.8.37
 
 - Added support for macOS Preview (via @iloveitaly)

--- a/doc/README.md
+++ b/doc/README.md
@@ -81,6 +81,19 @@ path = some/path in your/home
 path = /some path/in/your/root
 ```
 
+### Copying Symlinks as Links
+
+By default, when Mackup backs up the application configuration, any symbolic
+links to files results in the destination file being copied into the backup.
+
+You can optionally configure Mackup to ensure that any Symlinks are copied as
+Links, and not files:
+
+```ini
+[storage]
+copy_symlinks = true
+```
+
 ### Custom Directory Name
 
 You can customize the directory name in which Mackup stores your file. By

--- a/mackup/config.py
+++ b/mackup/config.py
@@ -57,6 +57,9 @@ class Config(object):
         # Get the directory replacing 'Mackup', if any
         self._directory = self._parse_directory()
 
+        # Get the copy_symlinks value
+        self._copy_symlinks = self._parse_symlinks()
+
         # Get the list of apps to ignore
         self._apps_to_ignore = self._parse_apps_to_ignore()
 
@@ -130,6 +133,16 @@ class Config(object):
             set. Set of application names to allow, lowercase
         """
         return set(self._apps_to_sync)
+
+    @property
+    def copy_symlinks(self):
+        """
+        The copy_symlinks flag status.
+
+        Returns:
+            bool
+        """
+        return bool(self._copy_symlinks)
 
     def _setup_parser(self, filename=None):
         """
@@ -225,6 +238,21 @@ class Config(object):
                 )
 
         return str(path)
+
+    def _parse_symlinks(self):
+        """
+        Parse the copy_symlinks setting in the config.
+
+        Returns:
+            bool
+        """
+        if self._parser.has_option("storage", "copy_symlinks"):
+            copy_symlinks = self._parser.getboolean("storage", "copy_symlinks", fallback=False)
+        else:
+            copy_symlinks = False
+
+        return bool(copy_symlinks)
+
 
     def _parse_directory(self):
         """

--- a/mackup/main.py
+++ b/mackup/main.py
@@ -78,6 +78,8 @@ def main():
     if args["--root"]:
         utils.CAN_RUN_AS_ROOT = True
 
+    utils.COPY_SYMLINKS = mckp._config._copy_symlinks
+
     dry_run = args["--dry-run"]
 
     verbose = args["--verbose"]

--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -19,6 +19,8 @@ FORCE_YES = False
 # Flag that control if mackup can be run as root
 CAN_RUN_AS_ROOT = False
 
+# Are we going to copy symlinks as links?
+COPY_SYMLINKS = False
 
 def confirm(question):
     """
@@ -98,18 +100,19 @@ def copy(src, dst):
     # We need to copy a single file
     if os.path.isfile(src):
         # Copy the src file to dst
-        shutil.copy(src, dst)
+        shutil.copy(src, dst, follow_symlinks=not(COPY_SYMLINKS))
 
     # We need to copy a whole folder
     elif os.path.isdir(src):
-        shutil.copytree(src, dst)
+        shutil.copytree(src, dst, symlinks=COPY_SYMLINKS)
 
     # What the heck is this?
     else:
         raise ValueError("Unsupported file: {}".format(src))
 
     # Set the good mode to the file or folder recursively
-    chmod(dst)
+    if COPY_SYMLINKS == False:
+        chmod(dst)
 
 
 def link(target, link_to):

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -36,6 +36,9 @@ class TestConfig(unittest.TestCase):
         assert cfg.apps_to_ignore == set()
         assert cfg.apps_to_sync == set()
 
+        assert isinstance(cfg.copy_symlinks, bool)
+        assert cfg.copy_symlinks == False
+
     def test_config_empty(self):
         cfg = Config("mackup-empty.cfg")
 
@@ -53,6 +56,9 @@ class TestConfig(unittest.TestCase):
 
         assert cfg.apps_to_ignore == set()
         assert cfg.apps_to_sync == set()
+
+        assert isinstance(cfg.copy_symlinks, bool)
+        assert cfg.copy_symlinks == False
 
     def test_config_engine_dropbox(self):
         cfg = Config("mackup-engine-dropbox.cfg")
@@ -232,3 +238,9 @@ class TestConfig(unittest.TestCase):
 
     def test_config_old_config(self):
         self.assertRaises(SystemExit, Config, "mackup-old-config.cfg")
+
+    def test_config_copy_symlinks(self):
+        cfg = Config("mackup-copy-symlinks.cfg")
+
+        assert isinstance(cfg.copy_symlinks, bool)
+        assert cfg.copy_symlinks == True

--- a/tests/fixtures/mackup-copy-symlinks.cfg
+++ b/tests/fixtures/mackup-copy-symlinks.cfg
@@ -1,0 +1,2 @@
+[storage]
+copy_symlinks = 1


### PR DESCRIPTION
### All submissions

* [ ] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [ ] This PR is only for one application
* [ ] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [ ] Changes have been added to the WIP section of the [CHANGELOG](https://github.com/lra/mackup/blob/master/CHANGELOG.md)
* [ ] Syncing does not break the application
* [ ] Syncing does not compete with any syncing functionality internal to the application
* [ ] The configuration syncs the minimal set of data
* [ ] No file specific to the local workstation is synced
* [ ] No sensitive data is synced

### Improving the Mackup codebase

* [ ] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [ ] I have linted the code locally prior to submission
* [ ] I have written new tests as applicable
* [ ] I have added an explanation of what the changes do
